### PR TITLE
check filetype

### DIFF
--- a/plugin/gofmtmd.vim
+++ b/plugin/gofmtmd.vim
@@ -16,7 +16,7 @@ command! GoFmtMd :call gofmtmd#execFmt()
 if get(g:, 'gofmtmd_auto_fmt', 0)
     augroup gofmtmd_autofmt
         autocmd!
-        autocmd BufWritePost *.md :call gofmtmd#execFmt()
+        autocmd BufWritePost * if &ft == 'markdown' | :call gofmtmd#execFmt() | endif
     augroup END
 endif
 


### PR DESCRIPTION
Improved to check file type instead of file extension.
By checking the file type, it doesn't depend on the file extension, so `*.markdown` can be supported for files other than `*.md`.